### PR TITLE
Name change for gomnd to mnd

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,10 +10,11 @@ linters:
     - godot             # annoying - ending all comments with periods
     - goerr113          # annoying - no dynamic errors, forces named errors or wrapping errors - annoying
     - golint            # replaced by stylecheck
-    - gomnd             # annoying - magic numbers more annoying to alert on than deal with
+    - gomnd             # deprecated
     - ifshort           # deprecated
     - interfacer        # deprecated
     - maligned          # deprecated
+    - mnd               # annoying - magic numbers more annoying to alert on than deal with
     - nosnakecase       # deprecated
     - scopelint         # deprecated
     - structcheck       # deprecated


### PR DESCRIPTION
The `gomnd` linter [has been renamed](https://github.com/golangci/golangci-lint/pull/4572) to `mnd` and started alerting in our lint jobs. This disables it again.