### PR TITLE
update linters, disable/remove deprecated

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,16 +5,13 @@ linters:
     - bodyclose         # this should all be handled by httpclient, but linter isn't smart enough to detect - enable case-by-case later?
     - depguard          # annoying - must maintain a constant whitelist of import-able packages
     - err113            # annoying - no dynamic errors, forces named errors or wrapping errors
-    - execinquery       # deprecated
     - exhaustruct       # annoying - forces full struct initializations
     - godot             # annoying - ending all comments with periods
-    - gomnd             # deprecated
     - mnd               # annoying - magic numbers more annoying to alert on than deal with
     - tagalign          # forces you to use the tool to do non-standard alignment
     - tagliatelle       # annoying - enforces "no snake case" in JSON tags on things we don't control
     - intrange          # annoying - sometimes int ranges are okay, but forcing them doesn't always improve code clarity
-      # - revive
-      # - stylecheck
+    - tenv              # deprecated - Replaced by usetesting.
 linters-settings:
   forbidigo:
     forbid:


### PR DESCRIPTION
This PR updates the global linter configuration shared across multiple repositories.

## Changes

### Removed linters:

- execinquery – deprecated and deactivated
- gomd – deprecated and deactivated

### Disabled linter:

- tenv – Duplicate feature in another linter. Replaced by usetesting.