### PR TITLE
Update to golangci-lint v2 and it's new syntax

### DIFF
--- a/.golangci.bck.yml
+++ b/.golangci.bck.yml
@@ -1,0 +1,30 @@
+---
+linters:
+  enable-all: true
+  disable:
+    - bodyclose         # this should all be handled by httpclient, but linter isn't smart enough to detect - enable case-by-case later?
+    - depguard          # annoying - must maintain a constant whitelist of import-able packages
+    - err113            # annoying - no dynamic errors, forces named errors or wrapping errors
+    - exhaustruct       # annoying - forces full struct initializations
+    - godot             # annoying - ending all comments with periods
+    - mnd               # annoying - magic numbers more annoying to alert on than deal with
+    - tagalign          # forces you to use the tool to do non-standard alignment
+    - tagliatelle       # annoying - enforces "no snake case" in JSON tags on things we don't control
+    - intrange          # annoying - sometimes int ranges are okay, but forcing them doesn't always improve code clarity
+    - tenv              # deprecated - Replaced by usetesting.
+linters-settings:
+  forbidigo:
+    forbid:
+      - ^print.*$
+  dupl:
+    threshold: 1000
+  lll:
+    line-length: 150
+  nlreturn:
+    block-size: 2
+  gosec:
+    config:
+      G302: "0644"
+      G306: "0644"
+  perfsprint:
+    errorf: false       # annoying - forces errors.New() when no format strings in fmt.Errorf call

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,30 +1,52 @@
----
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
     - bodyclose         # this should all be handled by httpclient, but linter isn't smart enough to detect - enable case-by-case later?
     - depguard          # annoying - must maintain a constant whitelist of import-able packages
     - err113            # annoying - no dynamic errors, forces named errors or wrapping errors
     - exhaustruct       # annoying - forces full struct initializations
     - godot             # annoying - ending all comments with periods
+    - intrange          # annoying - sometimes int ranges are okay, but forcing them doesn't always improve code clarity
     - mnd               # annoying - magic numbers more annoying to alert on than deal with
     - tagalign          # forces you to use the tool to do non-standard alignment
     - tagliatelle       # annoying - enforces "no snake case" in JSON tags on things we don't control
-    - intrange          # annoying - sometimes int ranges are okay, but forcing them doesn't always improve code clarity
-    - tenv              # deprecated - Replaced by usetesting.
-linters-settings:
-  forbidigo:
-    forbid:
-      - ^print.*$
-  dupl:
-    threshold: 1000
-  lll:
-    line-length: 150
-  nlreturn:
-    block-size: 2
-  gosec:
-    config:
-      G302: "0644"
-      G306: "0644"
-  perfsprint:
-    errorf: false       # annoying - forces errors.New() when no format strings in fmt.Errorf call
+  settings:
+    dupl:
+      threshold: 1000
+    forbidigo:
+      forbid:
+        - pattern: ^print.*$
+    gosec:
+      config:
+        G302: "0644"
+        G306: "0644"
+    lll:
+      line-length: 150
+    nlreturn:
+      block-size: 2
+    perfsprint:
+      errorf: false       # annoying - forces errors.New() when no format strings in fmt.Errorf call
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
Migration to new v2 of Golangcli-lint syntax