### PR TITLE
Updated disabled linters to handle additions/changes for v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,15 +2,18 @@ version: "2"
 linters:
   default: all
   disable:
-    - bodyclose         # this should all be handled by httpclient, but linter isn't smart enough to detect - enable case-by-case later?
-    - depguard          # annoying - must maintain a constant whitelist of import-able packages
-    - err113            # annoying - no dynamic errors, forces named errors or wrapping errors
-    - exhaustruct       # annoying - forces full struct initializations
-    - godot             # annoying - ending all comments with periods
-    - intrange          # annoying - sometimes int ranges are okay, but forcing them doesn't always improve code clarity
-    - mnd               # annoying - magic numbers more annoying to alert on than deal with
-    - tagalign          # forces you to use the tool to do non-standard alignment
-    - tagliatelle       # annoying - enforces "no snake case" in JSON tags on things we don't control
+    - bodyclose                # this should all be handled by httpclient, but linter isn't smart enough to detect - enable case-by-case later?
+    - depguard                 # annoying - must maintain a constant whitelist of import-able packages
+    - err113                   # annoying - no dynamic errors, forces named errors or wrapping errors
+    - exhaustruct              # annoying - forces full struct initializations
+    - godot                    # annoying - ending all comments with periods
+    - intrange                 # annoying - sometimes int ranges are okay, but forcing them doesn't always improve code clarity
+    - mnd                      # annoying - magic numbers more annoying to alert on than deal with
+    - tagalign                 # forces you to use the tool to do non-standard alignment
+    - tagliatelle              # annoying - enforces "no snake case" in JSON tags on things we don't control
+    - noinlineerr              # Disabled during v2 conversion - new linting errors
+    - funcorder                # Disabled during v2 conversion - new linting errors
+    - embeddedstructfieldcheck # Disabled during v2 conversion - new linting errors
   settings:
     dupl:
       threshold: 1000


### PR DESCRIPTION
Changes between v1 and v2 required changes so previously passing code would not fail