### PR TITLE
Further updates to config after conversion to golangci-lint v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - noinlineerr              # Disabled during v2 conversion - new linting errors
     - funcorder                # Disabled during v2 conversion - new linting errors
     - embeddedstructfieldcheck # Disabled during v2 conversion - new linting errors
+    - wsl                      # Deprecated and replaced with wsl_v5 since v2.2.0
   settings:
     dupl:
       threshold: 1000
@@ -30,6 +31,10 @@ linters:
       block-size: 2
     perfsprint:
       errorf: false       # annoying - forces errors.New() when no format strings in fmt.Errorf call
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
   exclusions:
     generated: lax
     presets:
@@ -45,8 +50,8 @@ formatters:
   enable:
     - gci
     - gofmt
-    - gofumpt
     - goimports
+    #- gofumpt
   exclusions:
     generated: lax
     paths:


### PR DESCRIPTION
More adjustments after running more Go code through golangci-lint with the new v2 configuration.