### PR TITLE
chore: enable DefectDojo scan-only workflows

### DIFF
--- a/.github/workflows/defectdojo-branch-scan.yml
+++ b/.github/workflows/defectdojo-branch-scan.yml
@@ -1,0 +1,9 @@
+name: DefectDojo Branch Scan
+on:
+  push:
+    branches: ["**"]
+  workflow_dispatch:
+jobs:
+  scan:
+    uses: DefectDojo-Inc/defectdojo-scan-and-fix/.github/workflows/branch-scan-reusable.yml@main
+    secrets: inherit

--- a/.github/workflows/defectdojo-pr-cleanup.yml
+++ b/.github/workflows/defectdojo-pr-cleanup.yml
@@ -1,0 +1,8 @@
+name: DefectDojo PR Cleanup
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  cleanup:
+    uses: DefectDojo-Inc/defectdojo-scan-and-fix/.github/workflows/pr-cleanup-reusable.yml@main
+    secrets: inherit

--- a/.github/workflows/defectdojo-pr-scan.yml
+++ b/.github/workflows/defectdojo-pr-scan.yml
@@ -1,0 +1,8 @@
+name: DefectDojo PR Scan
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  scan:
+    uses: DefectDojo-Inc/defectdojo-scan-and-fix/.github/workflows/pr-scan-reusable.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adopts the zero-config DefectDojo scanning workflows so PRs get an automatic security scan + finding-diff against the base branch baseline, and net-new findings fail the check.

Three byte-identical files; no per-repo customization. Everything else is handled by the [DefectDojo-Inc/defectdojo-scan-and-fix](https://github.com/DefectDojo-Inc/defectdojo-scan-and-fix#quick-start) action.

## Required org secrets

These must be present on the `DefectDojo-Inc` org (scoped to this repo) before the workflows can run:

- `DEFECTDOJO_URL`
- `DEFECTDOJO_TOKEN`

## What to expect

- **First PR after merge** against any branch will take ~2× normal scan time while the lazy baseline runs. Subsequent PRs are fast.
- Net-new findings (versus the base branch baseline) **fail the check**. To make the gate enforced, mark `PR Security Scan / scan` as a required status check in branch protection — and remember to protect the branch you actually open PRs against (e.g. `dev`), not just `main`/`master`.
- PR cleanup workflow removes the ephemeral PR engagement from DefectDojo when the PR closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)